### PR TITLE
Fix query statement in SyncMain.java which contains not WHERE but…

### DIFF
--- a/src/main/java/com/azure/cosmos/sample/sync/SyncMain.java
+++ b/src/main/java/com/azure/cosmos/sample/sync/SyncMain.java
@@ -182,7 +182,7 @@ public class SyncMain {
         queryOptions.setPopulateQueryMetrics(true);
 
         CosmosPagedIterable<Family> familiesPagedIterable = container.queryItems(
-            "SELECT * FROM Family WHfERE Family.lastName IN ('Andersen', 'Wakefield', 'Johnson')", queryOptions, Family.class);
+            "SELECT * FROM Family WHERE Family.lastName IN ('Andersen', 'Wakefield', 'Johnson')", queryOptions, Family.class);
 
         familiesPagedIterable.iterableByPage(10).forEach(cosmosItemPropertiesFeedResponse -> {
             System.out.println("Got a page of query result with " +


### PR DESCRIPTION
Just a typo. Query statement in method queryItems in SyncMain.java is not valid since the statement contains not WHERE but WHfERE.